### PR TITLE
add the functionality to start the tagging process when the current build was not successfully. 

### DIFF
--- a/src/main/java/hudson/plugins/svn_tag/SvnTagPlugin.java
+++ b/src/main/java/hudson/plugins/svn_tag/SvnTagPlugin.java
@@ -59,10 +59,10 @@ public class SvnTagPlugin {
                                   Launcher launcher,
                                   BuildListener buildListener,
                                   String tagBaseURLStr, String tagComment,
-                                  String tagDeleteComment) throws IOException, InterruptedException {
+                                  String tagDeleteComment, boolean activateOnBuildSuccess) throws IOException, InterruptedException {
         PrintStream logger = buildListener.getLogger();
 
-        if (Result.SUCCESS!=abstractBuild.getResult()) {
+        if ((activateOnBuildSuccess == true) && (Result.SUCCESS!=abstractBuild.getResult())) {
             logger.println(Messages.UnsuccessfulBuild());
             return true;
         }

--- a/src/main/java/hudson/plugins/svn_tag/SvnTagPublisher.java
+++ b/src/main/java/hudson/plugins/svn_tag/SvnTagPublisher.java
@@ -37,6 +37,8 @@ public class SvnTagPublisher extends Notifier {
     private String tagBaseURL = null;
 
     private String tagComment = null;
+    
+    private boolean activateOnBuildSuccess = true;
 
     @Deprecated
     private transient String tagMkdirComment;
@@ -44,10 +46,11 @@ public class SvnTagPublisher extends Notifier {
     private String tagDeleteComment = null;
 
     @DataBoundConstructor
-    public SvnTagPublisher(String tagBaseURL, String tagComment, String tagDeleteComment) {
+    public SvnTagPublisher(String tagBaseURL, String tagComment, String tagDeleteComment, boolean activateOnBuildSuccess) {
         this.tagBaseURL = tagBaseURL;
         this.tagComment = tagComment;
         this.tagDeleteComment = tagDeleteComment;
+        this.activateOnBuildSuccess = activateOnBuildSuccess;
     }
 
     /**
@@ -66,6 +69,10 @@ public class SvnTagPublisher extends Notifier {
     public String getTagDeleteComment() {
         return this.tagDeleteComment;
     }
+    
+    public boolean getActivateOnBuildSuccess() {
+        return this.activateOnBuildSuccess;
+    }    
 
     public BuildStepMonitor getRequiredMonitorService() {
         return BuildStepMonitor.BUILD;
@@ -78,7 +85,7 @@ public class SvnTagPublisher extends Notifier {
             throws InterruptedException, IOException {
         return SvnTagPlugin.perform(abstractBuild, launcher, buildListener,
                 this.getTagBaseURL(), this.getTagComment(),
-                this.getTagDeleteComment());
+                this.getTagDeleteComment(), this.getActivateOnBuildSuccess());
     }
 
     @Override
@@ -108,6 +115,7 @@ public class SvnTagPublisher extends Notifier {
         private transient String tagMkdirComment;
 
         private String tagDeleteComment;
+        
 
         /**
          * Creates a new SvnTagDescriptorImpl object.
@@ -198,7 +206,7 @@ public class SvnTagPublisher extends Notifier {
         public void setTagDeleteComment(String tagDeleteComment) {
             this.tagDeleteComment = tagDeleteComment;
         }
-
+        
         public FormValidation doCheckTagComment(@QueryParameter final String value) {
             try {
                 SvnTagPlugin.evalGroovyExpression(

--- a/src/main/resources/hudson/plugins/svn_tag/Messages.properties
+++ b/src/main/resources/hudson/plugins/svn_tag/Messages.properties
@@ -1,5 +1,7 @@
 DisplayName=Perform Subversion tagging on successful build
 DefaultTagBaseURL='http://subversion_host/project/tags/last-successful/${env[''JOB_NAME'']}'
+ActivateOnBuildSuccess='Activate process only when build was successfully'
+DefaultActivateOnBuildSuccess='1'
 DefaultTagComment='Tagged by Jenkins svn-tag plugin. Build:${env[''BUILD_TAG'']}.'
 DefaultTagDeleteComment=Delete old tag by svn-tag Jenkins plugin.
 MissingURL=Please specify URL.

--- a/src/main/resources/hudson/plugins/svn_tag/Messages_de.properties
+++ b/src/main/resources/hudson/plugins/svn_tag/Messages_de.properties
@@ -1,5 +1,7 @@
 DisplayName=Erstellt Subversion Tags für erfolgreiche Builds.
 DefaultTagBaseURL='http://subversion_host/project/tags/last-successful/${env[''JOB_NAME'']}'
+ActivateOnBuildSuccess='Aktiviert das erstellen eines Subversion Tags nur bei erfolgreichen Builds'
+DefaultActivateOnBuildSuccess='1'
 DefaultTagComment='Tag erzeugt durch SvnTag Plugin. Build:${env[''BUILD_TAG'']}.'
 DefaultTagDeleteComment=Tag gelöscht durch SvnTag Plugin.
 MissingURL=Bitte geben Sie eine gültige URL ein.

--- a/src/main/resources/hudson/plugins/svn_tag/SvnTagPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/svn_tag/SvnTagPublisher/config.jelly
@@ -1,4 +1,10 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+
+  <f:entry title="${%Activation on build success}" field="activateOnBuildSuccess"
+		help="${descriptor.getHelpFile('tagActivateOnBuildSuccess')}">
+    <f:checkbox default="true" name="activateOnBuildSuccess"/>
+  </f:entry>
+  
   <f:entry title="${%Tag Base URL}" field="tagBaseURL">
     <f:textbox default="${descriptor.defaultTagBaseURL}"/>
   </f:entry>

--- a/src/main/resources/hudson/plugins/svn_tag/SvnTagPublisher/help-tagActivateOnBuildSuccess.html
+++ b/src/main/resources/hudson/plugins/svn_tag/SvnTagPublisher/help-tagActivateOnBuildSuccess.html
@@ -1,0 +1,3 @@
+<div>
+	When the checkbox is unchecked, the tagging process will be startetd regardless of the build state. In some cases this is helpful ;).
+</div>


### PR DESCRIPTION
add the functionality to start the tagging process when the current build was not successfully. 
For this feature a new checkbox was added to the project specific 
configuration. The default value is checked. When the value is unchecked
the tagging process started regardless of the build state. In some
situations it is helpful when the tagging starts without the success
condition.
