### PR TITLE
[JENKINS-26217] Enable support for HEAD (v2.5) Subversion plugin.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.424</version>
+        <version>1.568</version>
     </parent>
     <artifactId>svn-tag</artifactId>
     <name>Jenkins Subversion Tagging Plugin</name>
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>subversion</artifactId>
-            <version>2.2</version>
+            <version>2.5</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.568</version>
+        <version>1.597</version>
     </parent>
     <artifactId>svn-tag</artifactId>
     <name>Jenkins Subversion Tagging Plugin</name>


### PR DESCRIPTION
Have applied supplied patch to make svn-tag-plugin work with subversion plugin 2.5 so that people can use us subversion 1.8 with jenkins with this plugin
