### PR TITLE
[JENKINS-28047] Added waitBeforeTagging configuration parameter

### DIFF
--- a/src/main/java/hudson/plugins/svn_tag/SvnTagPlugin.java
+++ b/src/main/java/hudson/plugins/svn_tag/SvnTagPlugin.java
@@ -59,7 +59,8 @@ public class SvnTagPlugin {
                                   Launcher launcher,
                                   BuildListener buildListener,
                                   String tagBaseURLStr, String tagComment,
-                                  String tagDeleteComment, Integer waitBeforeTagging) throws IOException, InterruptedException {
+                                  String tagDeleteComment, Integer waitBeforeTagging)
+                                          throws IOException, InterruptedException {
         PrintStream logger = buildListener.getLogger();
         logger.println("Starting to tag");
 
@@ -170,8 +171,7 @@ public class SvnTagPlugin {
                 logger.println(Messages.NoOldTag(evaledTagBaseURLStr));
             }
 
-            if(null != waitBeforeTagging && waitBeforeTagging > 0 )
-            {
+            if(null != waitBeforeTagging && waitBeforeTagging > 0 ) {
                 logger.println(Messages.WaitBeforeTagging(waitBeforeTagging));
                 Thread.sleep(waitBeforeTagging*1000);
             }

--- a/src/main/java/hudson/plugins/svn_tag/SvnTagPlugin.java
+++ b/src/main/java/hudson/plugins/svn_tag/SvnTagPlugin.java
@@ -49,6 +49,8 @@ public class SvnTagPlugin {
      * @param buildListener build listener
      * @param tagBaseURLStr tag base URL string
      * @param tagComment    tag comment
+     * @param tagDeleteComment tag delete comment
+     * @param waitBeforeTagging wait time before tagging in seconds
      * @return true if the operation was successful
      * @throws InterruptedException 
      * @throws IOException 

--- a/src/main/java/hudson/plugins/svn_tag/SvnTagPlugin.java
+++ b/src/main/java/hudson/plugins/svn_tag/SvnTagPlugin.java
@@ -59,7 +59,7 @@ public class SvnTagPlugin {
                                   Launcher launcher,
                                   BuildListener buildListener,
                                   String tagBaseURLStr, String tagComment,
-                                  String tagDeleteComment) throws IOException, InterruptedException {
+                                  String tagDeleteComment, Integer waitBeforeTagging) throws IOException, InterruptedException {
         PrintStream logger = buildListener.getLogger();
         logger.println("Starting to tag");
 
@@ -168,6 +168,12 @@ public class SvnTagPlugin {
 
             } catch (SVNException e) {
                 logger.println(Messages.NoOldTag(evaledTagBaseURLStr));
+            }
+
+            if(null != waitBeforeTagging && waitBeforeTagging > 0 )
+            {
+                logger.println(Messages.WaitBeforeTagging(waitBeforeTagging));
+                Thread.sleep(waitBeforeTagging*1000);
             }
 
             SVNCopyClient copyClient = new SVNCopyClient(sam, null);

--- a/src/main/java/hudson/plugins/svn_tag/SvnTagPlugin.java
+++ b/src/main/java/hudson/plugins/svn_tag/SvnTagPlugin.java
@@ -97,26 +97,26 @@ public class SvnTagPlugin {
             revisions = parseRevisionFile(rootBuild);
         } catch (IOException e) {
             logger.println(
-                    Messages.FailedParsingRevisionFile(e.getLocalizedMessage()));
+            		Messages.FailedParsingRevisionFile(e.getLocalizedMessage()));
             return false;
         }
 
         for (SubversionSCM.ModuleLocation ml : scm.getLocations(envVars, rootBuild)) {
-            String mlUrl;
-            URI repoURI;
-            try {
-                mlUrl = ml.getSVNURL().toString();
+			String mlUrl;
+        	URI repoURI;
+			try {
+				mlUrl = ml.getSVNURL().toString();
                 logger.println("Tagging " + mlUrl);
-                repoURI = new URI(mlUrl);
-            } catch (SVNException e) {
-                logger.println(
-                        Messages.FailedParsingRepositoryURL(ml.remote, e.getLocalizedMessage()));
-                return false;
-            } catch (URISyntaxException e) {
-                logger.println(
-                        Messages.FailedParsingRepositoryURL(ml.remote, e.getLocalizedMessage()));
-                return false;
-            }
+				repoURI = new URI(mlUrl);
+			} catch (SVNException e) {
+        		logger.println(
+        				Messages.FailedParsingRepositoryURL(ml.remote, e.getLocalizedMessage()));
+        		return false;
+			} catch (URISyntaxException e) {
+        		logger.println(
+        				Messages.FailedParsingRepositoryURL(ml.remote, e.getLocalizedMessage()));
+        		return false;
+        	}
             Long revision = revisions.get(mlUrl);
             if (revision == null) {
                 // this can happen for example if the project configuration changes since this build.
@@ -124,11 +124,11 @@ public class SvnTagPlugin {
                 continue;
             }
 
-            logger.println(Messages.RemoteModuleLocation(mlUrl+'@'+revision));
+        	logger.println(Messages.RemoteModuleLocation(mlUrl+'@'+revision));
 
             List<String> locationPathElements = Arrays.asList(StringUtils.split(mlUrl, "/"));
             String evaledTagBaseURLStr = evalGroovyExpression(
-                    envVars, tagBaseURLStr, locationPathElements);
+            		envVars, tagBaseURLStr, locationPathElements);
 
             SVNURL parsedTagBaseURL = null;
             try {
@@ -137,7 +137,7 @@ public class SvnTagPlugin {
                 logger.println(Messages.TagBaseURL(parsedTagBaseURL.toString()));
             } catch (SVNException e) {
                 logger.println(Messages.FailedParsingTagBaseURL(
-                           evaledTagBaseURLStr, e.getLocalizedMessage()));
+           				evaledTagBaseURLStr, e.getLocalizedMessage()));
             }
 
             ISVNAuthenticationProvider sap = scm.createAuthenticationProvider(rootProject, ml);
@@ -154,7 +154,7 @@ public class SvnTagPlugin {
             SVNCommitClient commitClient = new SVNCommitClient(sam, null);
             try {
                 String evalDeleteComment = evalGroovyExpression(
-                        envVars, tagDeleteComment, locationPathElements);
+                		envVars, tagDeleteComment, locationPathElements);
                 SVNCommitInfo deleteInfo =
                         commitClient.doDelete(new SVNURL[]{parsedTagBaseURL},
                                 evalDeleteComment);
@@ -170,7 +170,8 @@ public class SvnTagPlugin {
                 logger.println(Messages.NoOldTag(evaledTagBaseURLStr));
             }
 
-            if(null != waitBeforeTagging && waitBeforeTagging > 0 ) {
+            if(null != waitBeforeTagging && waitBeforeTagging > 0 )
+            {
                 logger.println(Messages.WaitBeforeTagging(waitBeforeTagging));
                 Thread.sleep(waitBeforeTagging*1000);
             }
@@ -186,7 +187,7 @@ public class SvnTagPlugin {
                 SVNCommitInfo commitInfo =
                         copyClient.doCopy(new SVNCopySource[] {
                                     new SVNCopySource(rev, rev, 
-                                            SVNURL.parseURIEncoded(mlUrl)) },
+                                    		SVNURL.parseURIEncoded(mlUrl)) },
                                 parsedTagBaseURL, false,
                                 true, false, evalComment, new SVNProperties());
                 SVNErrorMessage errorMsg = commitInfo.getErrorMessage();
@@ -259,12 +260,12 @@ public class SvnTagPlugin {
                     continue;   // invalid line?
                 }
                 try {
-                    revisions.put(SVNURL.parseURIEncoded(line.substring(0, index)).toString(),
-                            Long.parseLong(line.substring(index + 1)));
+                	revisions.put(SVNURL.parseURIEncoded(line.substring(0, index)).toString(),
+                			Long.parseLong(line.substring(index + 1)));
                 } catch (NumberFormatException e) {
                     // perhaps a corrupted line. ignore
                 } catch(SVNException e) {
-                    // perhaps a corrupted line. ignore
+                	// perhaps a corrupted line. ignore
                 }
             }
         } finally {

--- a/src/main/java/hudson/plugins/svn_tag/SvnTagPlugin.java
+++ b/src/main/java/hudson/plugins/svn_tag/SvnTagPlugin.java
@@ -59,7 +59,7 @@ public class SvnTagPlugin {
                                   Launcher launcher,
                                   BuildListener buildListener,
                                   String tagBaseURLStr, String tagComment,
-                                  String tagDeleteComment, Integer waitBeforeTagging)
+                                  String tagDeleteComment, int waitBeforeTagging)
                                           throws IOException, InterruptedException {
         PrintStream logger = buildListener.getLogger();
         logger.println("Starting to tag");
@@ -171,7 +171,7 @@ public class SvnTagPlugin {
                 logger.println(Messages.NoOldTag(evaledTagBaseURLStr));
             }
 
-            if(null != waitBeforeTagging && waitBeforeTagging > 0 ) {
+            if(waitBeforeTagging > 0 ) {
                 logger.println(Messages.WaitBeforeTagging(waitBeforeTagging));
                 Thread.sleep(waitBeforeTagging*1000);
             }

--- a/src/main/java/hudson/plugins/svn_tag/SvnTagPlugin.java
+++ b/src/main/java/hudson/plugins/svn_tag/SvnTagPlugin.java
@@ -97,26 +97,26 @@ public class SvnTagPlugin {
             revisions = parseRevisionFile(rootBuild);
         } catch (IOException e) {
             logger.println(
-            		Messages.FailedParsingRevisionFile(e.getLocalizedMessage()));
+                    Messages.FailedParsingRevisionFile(e.getLocalizedMessage()));
             return false;
         }
 
         for (SubversionSCM.ModuleLocation ml : scm.getLocations(envVars, rootBuild)) {
-			String mlUrl;
-        	URI repoURI;
-			try {
-				mlUrl = ml.getSVNURL().toString();
+            String mlUrl;
+            URI repoURI;
+            try {
+                mlUrl = ml.getSVNURL().toString();
                 logger.println("Tagging " + mlUrl);
-				repoURI = new URI(mlUrl);
-			} catch (SVNException e) {
-        		logger.println(
-        				Messages.FailedParsingRepositoryURL(ml.remote, e.getLocalizedMessage()));
-        		return false;
-			} catch (URISyntaxException e) {
-        		logger.println(
-        				Messages.FailedParsingRepositoryURL(ml.remote, e.getLocalizedMessage()));
-        		return false;
-        	}
+                repoURI = new URI(mlUrl);
+            } catch (SVNException e) {
+                logger.println(
+                        Messages.FailedParsingRepositoryURL(ml.remote, e.getLocalizedMessage()));
+                return false;
+            } catch (URISyntaxException e) {
+                logger.println(
+                        Messages.FailedParsingRepositoryURL(ml.remote, e.getLocalizedMessage()));
+                return false;
+            }
             Long revision = revisions.get(mlUrl);
             if (revision == null) {
                 // this can happen for example if the project configuration changes since this build.
@@ -124,11 +124,11 @@ public class SvnTagPlugin {
                 continue;
             }
 
-        	logger.println(Messages.RemoteModuleLocation(mlUrl+'@'+revision));
+            logger.println(Messages.RemoteModuleLocation(mlUrl+'@'+revision));
 
             List<String> locationPathElements = Arrays.asList(StringUtils.split(mlUrl, "/"));
             String evaledTagBaseURLStr = evalGroovyExpression(
-            		envVars, tagBaseURLStr, locationPathElements);
+                    envVars, tagBaseURLStr, locationPathElements);
 
             SVNURL parsedTagBaseURL = null;
             try {
@@ -137,7 +137,7 @@ public class SvnTagPlugin {
                 logger.println(Messages.TagBaseURL(parsedTagBaseURL.toString()));
             } catch (SVNException e) {
                 logger.println(Messages.FailedParsingTagBaseURL(
-           				evaledTagBaseURLStr, e.getLocalizedMessage()));
+                           evaledTagBaseURLStr, e.getLocalizedMessage()));
             }
 
             ISVNAuthenticationProvider sap = scm.createAuthenticationProvider(rootProject, ml);
@@ -154,7 +154,7 @@ public class SvnTagPlugin {
             SVNCommitClient commitClient = new SVNCommitClient(sam, null);
             try {
                 String evalDeleteComment = evalGroovyExpression(
-                		envVars, tagDeleteComment, locationPathElements);
+                        envVars, tagDeleteComment, locationPathElements);
                 SVNCommitInfo deleteInfo =
                         commitClient.doDelete(new SVNURL[]{parsedTagBaseURL},
                                 evalDeleteComment);
@@ -170,8 +170,7 @@ public class SvnTagPlugin {
                 logger.println(Messages.NoOldTag(evaledTagBaseURLStr));
             }
 
-            if(null != waitBeforeTagging && waitBeforeTagging > 0 )
-            {
+            if(null != waitBeforeTagging && waitBeforeTagging > 0 ) {
                 logger.println(Messages.WaitBeforeTagging(waitBeforeTagging));
                 Thread.sleep(waitBeforeTagging*1000);
             }
@@ -187,7 +186,7 @@ public class SvnTagPlugin {
                 SVNCommitInfo commitInfo =
                         copyClient.doCopy(new SVNCopySource[] {
                                     new SVNCopySource(rev, rev, 
-                                    		SVNURL.parseURIEncoded(mlUrl)) },
+                                            SVNURL.parseURIEncoded(mlUrl)) },
                                 parsedTagBaseURL, false,
                                 true, false, evalComment, new SVNProperties());
                 SVNErrorMessage errorMsg = commitInfo.getErrorMessage();
@@ -260,12 +259,12 @@ public class SvnTagPlugin {
                     continue;   // invalid line?
                 }
                 try {
-                	revisions.put(SVNURL.parseURIEncoded(line.substring(0, index)).toString(),
-                			Long.parseLong(line.substring(index + 1)));
+                    revisions.put(SVNURL.parseURIEncoded(line.substring(0, index)).toString(),
+                            Long.parseLong(line.substring(index + 1)));
                 } catch (NumberFormatException e) {
                     // perhaps a corrupted line. ignore
                 } catch(SVNException e) {
-                	// perhaps a corrupted line. ignore
+                    // perhaps a corrupted line. ignore
                 }
             }
         } finally {

--- a/src/main/java/hudson/plugins/svn_tag/SvnTagPublisher.java
+++ b/src/main/java/hudson/plugins/svn_tag/SvnTagPublisher.java
@@ -45,7 +45,7 @@ public class SvnTagPublisher extends Notifier {
 
     private String tagDeleteComment = null;
 
-	private Integer waitBeforeTagging = 0;
+    private Integer waitBeforeTagging = 0;
 
     @DataBoundConstructor
     public SvnTagPublisher(String tagBaseURL, String tagComment, String tagDeleteComment, Integer waitBeforeTagging) {
@@ -53,6 +53,10 @@ public class SvnTagPublisher extends Notifier {
         this.tagComment = tagComment;
         this.tagDeleteComment = tagDeleteComment;
         this.waitBeforeTagging = waitBeforeTagging;
+    }
+
+    public SvnTagPublisher(String tagBaseURL, String tagComment, String tagDeleteComment) {
+        this(tagBaseURL, tagComment, tagDeleteComment, 0);
     }
 
     /**
@@ -118,7 +122,7 @@ public class SvnTagPublisher extends Notifier {
 
         private String tagDeleteComment;
 
-		private Integer waitBeforeTagging;
+        private Integer waitBeforeTagging;
 
         /**
          * Creates a new SvnTagDescriptorImpl object.

--- a/src/main/java/hudson/plugins/svn_tag/SvnTagPublisher.java
+++ b/src/main/java/hudson/plugins/svn_tag/SvnTagPublisher.java
@@ -45,7 +45,7 @@ public class SvnTagPublisher extends Notifier {
 
     private String tagDeleteComment = null;
 
-	private Integer waitBeforeTagging = 0;
+    private Integer waitBeforeTagging = 0;
 
     @DataBoundConstructor
     public SvnTagPublisher(String tagBaseURL, String tagComment, String tagDeleteComment, Integer waitBeforeTagging) {
@@ -53,6 +53,10 @@ public class SvnTagPublisher extends Notifier {
         this.tagComment = tagComment;
         this.tagDeleteComment = tagDeleteComment;
         this.waitBeforeTagging = waitBeforeTagging;
+    }
+
+    public SvnTagPublisher(String tagBaseURL, String tagComment, String tagDeleteComment) {
+        this(tagBaseURL, tagComment, tagDeleteComment, 0);
     }
 
     /**

--- a/src/main/java/hudson/plugins/svn_tag/SvnTagPublisher.java
+++ b/src/main/java/hudson/plugins/svn_tag/SvnTagPublisher.java
@@ -45,7 +45,7 @@ public class SvnTagPublisher extends Notifier {
 
     private String tagDeleteComment = null;
 
-    private Integer waitBeforeTagging = 0;
+	private Integer waitBeforeTagging = 0;
 
     @DataBoundConstructor
     public SvnTagPublisher(String tagBaseURL, String tagComment, String tagDeleteComment, Integer waitBeforeTagging) {
@@ -53,10 +53,6 @@ public class SvnTagPublisher extends Notifier {
         this.tagComment = tagComment;
         this.tagDeleteComment = tagDeleteComment;
         this.waitBeforeTagging = waitBeforeTagging;
-    }
-
-    public SvnTagPublisher(String tagBaseURL, String tagComment, String tagDeleteComment) {
-        this(tagBaseURL, tagComment, tagDeleteComment, 0);
     }
 
     /**
@@ -122,7 +118,7 @@ public class SvnTagPublisher extends Notifier {
 
         private String tagDeleteComment;
 
-        private Integer waitBeforeTagging;
+		private Integer waitBeforeTagging;
 
         /**
          * Creates a new SvnTagDescriptorImpl object.

--- a/src/main/java/hudson/plugins/svn_tag/SvnTagPublisher.java
+++ b/src/main/java/hudson/plugins/svn_tag/SvnTagPublisher.java
@@ -1,6 +1,7 @@
 package hudson.plugins.svn_tag;
 
 import hudson.tasks.BuildStepMonitor;
+
 import java.io.IOException;
 import java.util.HashMap;
 
@@ -15,6 +16,7 @@ import hudson.tasks.Notifier;
 import hudson.tasks.Publisher;
 import hudson.util.FormValidation;
 import net.sf.json.JSONObject;
+
 import org.codehaus.groovy.control.CompilationFailedException;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
@@ -43,11 +45,14 @@ public class SvnTagPublisher extends Notifier {
 
     private String tagDeleteComment = null;
 
+	private Integer waitBeforeTagging = 0;
+
     @DataBoundConstructor
-    public SvnTagPublisher(String tagBaseURL, String tagComment, String tagDeleteComment) {
+    public SvnTagPublisher(String tagBaseURL, String tagComment, String tagDeleteComment, Integer waitBeforeTagging) {
         this.tagBaseURL = tagBaseURL;
         this.tagComment = tagComment;
         this.tagDeleteComment = tagDeleteComment;
+        this.waitBeforeTagging = waitBeforeTagging;
     }
 
     /**
@@ -67,6 +72,10 @@ public class SvnTagPublisher extends Notifier {
         return this.tagDeleteComment;
     }
 
+    public Integer getWaitBeforeTagging() {
+        return this.waitBeforeTagging;
+    }
+
     public BuildStepMonitor getRequiredMonitorService() {
         return BuildStepMonitor.BUILD;
     }
@@ -78,7 +87,7 @@ public class SvnTagPublisher extends Notifier {
             throws InterruptedException, IOException {
         return SvnTagPlugin.perform(abstractBuild, launcher, buildListener,
                 this.getTagBaseURL(), this.getTagComment(),
-                this.getTagDeleteComment());
+                this.getTagDeleteComment(), this.getWaitBeforeTagging());
     }
 
     @Override
@@ -109,6 +118,8 @@ public class SvnTagPublisher extends Notifier {
 
         private String tagDeleteComment;
 
+		private Integer waitBeforeTagging;
+
         /**
          * Creates a new SvnTagDescriptorImpl object.
          */
@@ -116,6 +127,7 @@ public class SvnTagPublisher extends Notifier {
             this.defaultTagBaseURL = Messages.DefaultTagBaseURL();
             this.tagComment = Messages.DefaultTagComment();
             this.tagDeleteComment = Messages.DefaultTagDeleteComment();
+            this.waitBeforeTagging = 0;
             load();
         }
 
@@ -217,6 +229,23 @@ public class SvnTagPublisher extends Notifier {
         public boolean isApplicable(Class<? extends AbstractProject> jobType) {
             // need to check if this is a subversion project??
             return true;
+        }
+
+        public Integer getWaitBeforeTagging() {
+            return waitBeforeTagging;
+        }
+
+        public void setWaitBeforeTagging(Integer waitBeforeTagging) {
+            this.waitBeforeTagging = waitBeforeTagging;
+        }
+
+        public FormValidation doCheckWaitBeforeTagging(@QueryParameter final String waitBeforeTagging) {
+            try {
+                Integer.parseInt(waitBeforeTagging);
+                return FormValidation.ok();
+            } catch (NumberFormatException e) {
+                return FormValidation.error(Messages.BadWaitBeforeTagging(e.getMessage()));
+            }
         }
 
     }

--- a/src/main/java/hudson/plugins/svn_tag/SvnTagPublisher.java
+++ b/src/main/java/hudson/plugins/svn_tag/SvnTagPublisher.java
@@ -45,10 +45,10 @@ public class SvnTagPublisher extends Notifier {
 
     private String tagDeleteComment = null;
 
-    private Integer waitBeforeTagging = 0;
+    private int waitBeforeTagging = 0;
 
     @DataBoundConstructor
-    public SvnTagPublisher(String tagBaseURL, String tagComment, String tagDeleteComment, Integer waitBeforeTagging) {
+    public SvnTagPublisher(String tagBaseURL, String tagComment, String tagDeleteComment, int waitBeforeTagging) {
         this.tagBaseURL = tagBaseURL;
         this.tagComment = tagComment;
         this.tagDeleteComment = tagDeleteComment;
@@ -76,7 +76,7 @@ public class SvnTagPublisher extends Notifier {
         return this.tagDeleteComment;
     }
 
-    public Integer getWaitBeforeTagging() {
+    public int getWaitBeforeTagging() {
         return this.waitBeforeTagging;
     }
 
@@ -122,7 +122,7 @@ public class SvnTagPublisher extends Notifier {
 
         private String tagDeleteComment;
 
-		private Integer waitBeforeTagging;
+        private int waitBeforeTagging;
 
         /**
          * Creates a new SvnTagDescriptorImpl object.
@@ -235,11 +235,11 @@ public class SvnTagPublisher extends Notifier {
             return true;
         }
 
-        public Integer getWaitBeforeTagging() {
+        public int getWaitBeforeTagging() {
             return waitBeforeTagging;
         }
 
-        public void setWaitBeforeTagging(Integer waitBeforeTagging) {
+        public void setWaitBeforeTagging(int waitBeforeTagging) {
             this.waitBeforeTagging = waitBeforeTagging;
         }
 

--- a/src/main/java/hudson/plugins/svn_tag/SvnTagPublisher.java
+++ b/src/main/java/hudson/plugins/svn_tag/SvnTagPublisher.java
@@ -76,6 +76,11 @@ public class SvnTagPublisher extends Notifier {
         return this.tagDeleteComment;
     }
 
+    /**
+     * Returns how many seconds to wait before tagging
+     * 
+     * @return how many seconds to wait before tagging
+     */
     public int getWaitBeforeTagging() {
         return this.waitBeforeTagging;
     }
@@ -235,14 +240,30 @@ public class SvnTagPublisher extends Notifier {
             return true;
         }
 
+        /**
+         * Returns how many seconds to wait before tagging
+         * 
+         * @return how many seconds to wait before tagging
+         */
         public int getWaitBeforeTagging() {
             return waitBeforeTagging;
         }
 
+        /**
+         * Sets how many seconds to wait before tagging
+         * 
+         * @param waitBeforeTagging
+         */
         public void setWaitBeforeTagging(int waitBeforeTagging) {
             this.waitBeforeTagging = waitBeforeTagging;
         }
 
+        /**
+         * Validate WaitBeforeTagging parameter - value should be numeric
+         * 
+         * @param waitBeforeTagging
+         * @return
+         */
         public FormValidation doCheckWaitBeforeTagging(@QueryParameter final String waitBeforeTagging) {
             try {
                 Integer.parseInt(waitBeforeTagging);

--- a/src/main/java/hudson/plugins/svn_tag/SvnTagPublisher.java
+++ b/src/main/java/hudson/plugins/svn_tag/SvnTagPublisher.java
@@ -266,7 +266,10 @@ public class SvnTagPublisher extends Notifier {
          */
         public FormValidation doCheckWaitBeforeTagging(@QueryParameter final String waitBeforeTagging) {
             try {
-                Integer.parseInt(waitBeforeTagging);
+                int value = Integer.parseInt(waitBeforeTagging);
+                if(value < 0) {
+                    return FormValidation.error(Messages.NegativeWaitBeforeTagging());
+                }
                 return FormValidation.ok();
             } catch (NumberFormatException e) {
                 return FormValidation.error(Messages.BadWaitBeforeTagging(e.getMessage()));

--- a/src/main/resources/hudson/plugins/svn_tag/Messages.properties
+++ b/src/main/resources/hudson/plugins/svn_tag/Messages.properties
@@ -20,3 +20,4 @@ FailedParsingRevisionFile=Failed to parse revision.txt. {0}
 FailedToTag=Creating the tag failed with the following error: {0}
 WaitBeforeTagging=Waiting for {0} seconds before tagging
 BadWaitBeforeTagging=Wait before tagging value should be integer. {0}
+NegativeWaitBeforeTagging=Wait before tagging value should be 0 or higher.

--- a/src/main/resources/hudson/plugins/svn_tag/Messages.properties
+++ b/src/main/resources/hudson/plugins/svn_tag/Messages.properties
@@ -18,3 +18,5 @@ RemoteModuleLocation=Remote Module Location: {0}.
 NoSVNAuthProvider=No subversion authentication provider available.
 FailedParsingRevisionFile=Failed to parse revision.txt. {0}
 FailedToTag=Creating the tag failed with the following error: {0}
+WaitBeforeTagging=Waiting for {0} seconds before tagging
+BadWaitBeforeTagging=Wait before tagging value should be integer. {0}

--- a/src/main/resources/hudson/plugins/svn_tag/SvnTagPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/svn_tag/SvnTagPublisher/config.jelly
@@ -9,4 +9,8 @@
            help="${descriptor.getHelpFile('tagComment')}">
     <f:textbox default="${descriptor.tagDeleteComment}"/>
   </f:entry>
+  <f:entry title="${%Wait Before Tagging}" field="waitBeforeTagging"
+           help="${descriptor.getHelpFile('waitBeforeTagging')}">
+    <f:textbox default="${descriptor.waitBeforeTagging}"/>
+  </f:entry>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/svn_tag/SvnTagPublisher/global.jelly
+++ b/src/main/resources/hudson/plugins/svn_tag/SvnTagPublisher/global.jelly
@@ -12,5 +12,9 @@
              help="${descriptor.getHelpFile('tagComment')}">
       <f:textbox/>
     </f:entry>
+    <f:entry title="${%Wait before tagging}" field="waitBeforeTagging"
+             help="${descriptor.getHelpFile('waitBeforeTagging')}">
+      <f:textbox/>
+    </f:entry>
   </f:section>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/svn_tag/SvnTagPublisher/help-waitBeforeTagging.html
+++ b/src/main/resources/hudson/plugins/svn_tag/SvnTagPublisher/help-waitBeforeTagging.html
@@ -1,0 +1,4 @@
+<div>
+Wait the specified number of seconds before creating the tag.<br> 
+waitBeforeTagging is useful when your source repository is synced between several instances and access to it is determined by geographical location, like the SVN repository at the Apache Software Foundation.
+</div>

--- a/src/main/resources/hudson/plugins/svn_tag/SvnTagPublisher/help-waitBeforeTagging.html
+++ b/src/main/resources/hudson/plugins/svn_tag/SvnTagPublisher/help-waitBeforeTagging.html
@@ -1,4 +1,2 @@
-<div>
-Wait the specified number of seconds before creating the tag.<br> 
-waitBeforeTagging is useful when your source repository is synced between several instances and access to it is determined by geographical location, like the SVN repository at the Apache Software Foundation.
-</div>
+<p>Wait the specified number of seconds before creating the tag.</p> 
+<p><code>waitBeforeTagging</code> is useful when your source repository is synced between several instances and access to it is determined by geographical location, like the SVN repository at the Apache Software Foundation.</p>


### PR DESCRIPTION
Wait the specified number of seconds before creating the tag (after delete previous tag).
waitBeforeTagging is useful when your source repository is synced between several instances and access to it is determined by geographical location, like the SVN repository at the Apache Software Foundation.
