### PR TITLE
Use supplied credentials

### DIFF
--- a/src/main/java/hudson/plugins/svn_tag/SvnTagPlugin.java
+++ b/src/main/java/hudson/plugins/svn_tag/SvnTagPlugin.java
@@ -147,8 +147,7 @@ public class SvnTagPlugin {
                 return false;
             }
 
-            ISVNAuthenticationManager sam =
-                    SVNWCUtil.createDefaultAuthenticationManager();
+            ISVNAuthenticationManager sam = SubversionSCM.createSvnAuthenticationManager(sap);
             sam.setAuthenticationProvider(sap);
 
             SVNCommitClient commitClient = new SVNCommitClient(sam, null);


### PR DESCRIPTION
Use Jenkins Authentication Manager to force use of supplied credentials
[FIXED JENKINS-28615]