### PR TITLE
[JENKINS-26611] SvnTagPublisher aborted java.lang.NoSuchMethodError

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.424</version>
+        <version>1.568</version>
     </parent>
     <artifactId>svn-tag</artifactId>
     <name>Jenkins Subversion Tagging Plugin</name>
@@ -39,7 +39,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>subversion</artifactId>
-            <version>2.2</version>
+            <version>2.5</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/hudson/plugins/svn_tag/SvnTagPlugin.java
+++ b/src/main/java/hudson/plugins/svn_tag/SvnTagPlugin.java
@@ -6,9 +6,11 @@ import hudson.EnvVars;
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
+import hudson.model.Run;
 import hudson.model.BuildListener;
 import hudson.model.Result;
 import hudson.scm.SubversionSCM;
+
 import org.apache.commons.lang.StringUtils;
 import org.codehaus.groovy.control.CompilerConfiguration;
 import org.tmatesoft.svn.core.*;
@@ -238,7 +240,7 @@ public class SvnTagPlugin {
         Map<String, Long> revisions =
                 new HashMap<String, Long>(); // module -> revision
         // read the revision file of the last build
-        File file = SubversionSCM.getRevisionFile(build);
+        File file = SubversionSCM.getRevisionFile((Run) build);
         if (!file.exists()) // nothing to compare against
         {
             return revisions;


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-26611

This PR is related to this [PR](https://github.com/jenkinsci/svn-tag-plugin/pull/10). I've created this new PR to include only changes that solve the bug.