### PR TITLE
[JENKINS-14606] - Fix issue with promoted build plugin

### DIFF
--- a/src/main/java/hudson/plugins/svn_tag/SvnTagPlugin.java
+++ b/src/main/java/hudson/plugins/svn_tag/SvnTagPlugin.java
@@ -85,7 +85,9 @@ public class SvnTagPlugin {
         }
 
         SubversionSCM scm = SubversionSCM.class.cast(rootProject.getScm());
-        EnvVars envVars = rootBuild.getEnvironment(buildListener);
+        EnvVars envVars = abstractBuild.getEnvironment(buildListener);
+        EnvVars rootVars = rootBuild.getEnvironment(buildListener);
+        envVars.putAll(rootVars);
 
         // Let SubversionSCM fill revision number.
         // It is guaranteed for getBuilds() return the latest build (i.e.


### PR DESCRIPTION
The svn-tag plugin takes the environment variables from the ancestor build
and not the actual build that was triggered. The issue can be solved if the
environment variables from the actual build are put in the var map and then
the ancestor build adds/overrides its environment variables to the map. That
would not change the original behaviour of the svn-tag plugin but add the
wanted functionality for it to work well together with the promoted build plugin.

This is a fix for [JENKINS-14606](https://issues.jenkins-ci.org/browse/JENKINS-14606)

Signed-off-by: Christian Gmeiner christian.gmeiner@gmail.com
